### PR TITLE
Fixed crash when encountering non-cp1252-encoded characters in log file.

### DIFF
--- a/edmmc/readlog.py
+++ b/edmmc/readlog.py
@@ -53,7 +53,7 @@ class ReadLog:
             self.current_log_name = latest
             if not self.current_log:
                 self.current_log.close()
-            self.current_log = open(latest, "r")
+            self.current_log = open(latest, "r", encoding="utf-8")
             self.is_game_running = True
             self.label_texts.ed_status.set("ED client is running")
             self.label_texts.current_log_status.set("Current log file: " +
@@ -159,7 +159,7 @@ class ReadLog:
             oldest_mission = min(self.current_missions.values())
             for journal in self.log_7days:
                 if os.path.getmtime(journal) >= oldest_mission:
-                    with open(journal, 'r') as log:
+                    with open(journal, 'r', encoding="utf-8") as log:
                         self.read_event(log, massacre_missions, False)
         except ValueError:
             # print("Empty mission list")


### PR DESCRIPTION
Useful project! I ran into this error after a while of running it:
```
Exception in Tkinter callback
Traceback (most recent call last):
  File "C:\Program Files\Python37\lib\tkinter\__init__.py", line 1705, in __call__
    return self.func(*args)
  File "C:\Program Files\Python37\lib\tkinter\__init__.py", line 749, in callit
    func(*args)
  File "edmmc.py", line 26, in update
    rl.update(self.missions, self.initialized)
  File "C:\Users\Keir\Documents\code\EDMMC\edmmc\readlog.py", line 350, in update
    new_events = self.current_log.readlines()
  File "C:\Program Files\Python37\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 385: character maps to <undefined>
```
which I guessed was a non-ASCII character in the ED log file, sure enough I was attacked by an unusually-named pirate:
```
{ "timestamp":"2021-04-14T16:46:38Z", "event":"ReceiveText", "From":"$npc_name_decorate:#name=Ákos Maróy;", "From_Localised":"Ákos Maróy", "Message":"$Pirate_OnStartScanCargo02;", "Message_Localised":"Carrying anything nice?", "Channel":"npc" }
```

Opening the log file as UTF-8 encoding fixed the issue.